### PR TITLE
Address loophole in cycle prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ async fn main() {
 
     // Add source tasks with no dependencies
     let x = dag.add_task(Value(2));
-    let y = dag.add_task(Value(3));
+    let y: TaskHandle<_> = dag.add_task(Value(3)).into();
 
-    // Add task that depends on both x and y
-    let sum = dag.add_task(Add).depends_on((&x, &y));
+    // Add task that depends on both x and y.
+    // Here, y could be reused as a dependency for other tasks, while x could not.
+    let sum = dag.add_task(Add).depends_on((x, &y));
 
     // Execute with true parallelism
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap();

--- a/benches/basic/execution.rs
+++ b/benches/basic/execution.rs
@@ -52,7 +52,7 @@ pub fn bench_dag_execution(c: &mut Criterion) {
                 let t0 = dag.add_task(Value(0));
                 let t1 = dag
                     .add_task(task_fn(|x: i32| async move { x + 1 }))
-                    .depends_on(&t0);
+                    .depends_on(t0);
                 let t2 = dag
                     .add_task(task_fn(|x: i32| async move { x + 1 }))
                     .depends_on(t1);

--- a/benches/comparisons/deep_chain.rs
+++ b/benches/comparisons/deep_chain.rs
@@ -3,6 +3,7 @@
 //! Long sequential chain: 100 tasks in sequence
 
 use criterion::Criterion;
+use dagx::TaskHandle;
 use futures::FutureExt;
 
 pub fn bench_deep_chain(c: &mut Criterion) {
@@ -17,10 +18,10 @@ pub fn bench_deep_chain(c: &mut Criterion) {
 
                 let dag = DagRunner::new();
 
-                let first = dag.add_task(task_fn(|_: ()| async { 0 }));
+                let first: TaskHandle<_> = dag.add_task(task_fn(|_: ()| async { 0 })).into();
                 let mut prev = dag
                     .add_task(task_fn(|x: i32| async move { x + 1 }))
-                    .depends_on(&first);
+                    .depends_on(first);
 
                 for i in 2..100 {
                     prev = dag

--- a/benches/comparisons/diamond_pattern.rs
+++ b/benches/comparisons/diamond_pattern.rs
@@ -3,6 +3,7 @@
 //! Classic diamond: A → B,C → D
 
 use criterion::Criterion;
+use dagx::TaskHandle;
 use futures::FutureExt;
 
 pub fn bench_diamond_pattern(c: &mut Criterion) {
@@ -17,13 +18,13 @@ pub fn bench_diamond_pattern(c: &mut Criterion) {
 
                 let dag = DagRunner::new();
 
-                let a = dag.add_task(task_fn(|_: ()| async { 10 }));
+                let a: TaskHandle<_> = dag.add_task(task_fn(|_: ()| async { 10 })).into();
                 let b = dag
                     .add_task(task_fn(|x: i32| async move { x * 2 }))
-                    .depends_on(&a);
+                    .depends_on(a);
                 let c = dag
                     .add_task(task_fn(|x: i32| async move { x + 5 }))
-                    .depends_on(&a);
+                    .depends_on(a);
                 let d = dag
                     .add_task(task_fn(|(x, y): (i32, i32)| async move { x + y }))
                     .depends_on((&b, &c));

--- a/benches/comparisons/etl_pipeline.rs
+++ b/benches/comparisons/etl_pipeline.rs
@@ -27,19 +27,19 @@ pub fn bench_etl_pipeline(c: &mut Criterion) {
                     .add_task(task_fn(|data: Vec<i32>| async move {
                         data.into_iter().map(|x| x * 2).collect::<Vec<_>>()
                     }))
-                    .depends_on(&source1);
+                    .depends_on(source1);
 
                 let transform2 = dag
                     .add_task(task_fn(|data: Vec<i32>| async move {
                         data.into_iter().map(|x| x * 2).collect::<Vec<_>>()
                     }))
-                    .depends_on(&source2);
+                    .depends_on(source2);
 
                 let transform3 = dag
                     .add_task(task_fn(|data: Vec<i32>| async move {
                         data.into_iter().map(|x| x * 2).collect::<Vec<_>>()
                     }))
-                    .depends_on(&source3);
+                    .depends_on(source3);
 
                 // Merge all transformed data
                 let merge = dag

--- a/benches/comparisons/linear_pipeline.rs
+++ b/benches/comparisons/linear_pipeline.rs
@@ -20,7 +20,7 @@ pub fn bench_linear_pipeline(c: &mut Criterion) {
                 let a = dag.add_task(task_fn(|_: ()| async { 1 }));
                 let b = dag
                     .add_task(task_fn(|x: i32| async move { x + 1 }))
-                    .depends_on(&a);
+                    .depends_on(a);
                 let c = dag
                     .add_task(task_fn(|x: i32| async move { x * 2 }))
                     .depends_on(b);

--- a/benches/patterns/diamond.rs
+++ b/benches/patterns/diamond.rs
@@ -1,7 +1,7 @@
 //! Diamond pattern benchmarks (fan-out then fan-in)
 
 use criterion::Criterion;
-use dagx::{task_fn, DagRunner};
+use dagx::{task_fn, DagRunner, TaskHandle};
 use futures::FutureExt;
 
 pub fn bench_diamond(c: &mut Criterion) {
@@ -13,14 +13,15 @@ pub fn bench_diamond(c: &mut Criterion) {
                 let dag = DagRunner::new();
 
                 for i in 0..50 {
-                    let source = dag.add_task(task_fn(move |_: ()| async move { i }));
+                    let source: TaskHandle<_> =
+                        dag.add_task(task_fn(move |_: ()| async move { i })).into();
 
                     let left = dag
                         .add_task(task_fn(|x: i32| async move { x * 2 }))
-                        .depends_on(&source);
+                        .depends_on(source);
                     let right = dag
                         .add_task(task_fn(|x: i32| async move { x * 3 }))
-                        .depends_on(&source);
+                        .depends_on(source);
 
                     dag.add_task(task_fn(|(l, r): (i32, i32)| async move { l + r }))
                         .depends_on((&left, &right));

--- a/docs/COMPARISONS.md
+++ b/docs/COMPARISONS.md
@@ -18,7 +18,7 @@ impl Add { async fn run(a: &i32, b: &i32) -> i32 { a + b } }
 let dag = DagRunner::new();
 let x = dag.add_task(Value(2));
 let y = dag.add_task(Value(3));
-let sum = dag.add_task(Add).depends_on((&x, &y));
+let sum = dag.add_task(Add).depends_on((x, y));
 dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 ```
 

--- a/examples/01_basic.rs
+++ b/examples/01_basic.rs
@@ -83,8 +83,8 @@ async fn main() {
     // Step 4: Add source tasks (tasks with no dependencies)
     //
     // add_task() returns a TaskHandle<T> where T is the task's output type
-    let x = dag.add_task(Value::new(2)); // TaskHandle<i32>
-    let y = dag.add_task(Value::new(3)); // TaskHandle<i32>
+    let x = dag.add_task(Value::new(2)).into(); // TaskHandle<i32>
+    let y = dag.add_task(Value::new(3)).into(); // TaskHandle<i32>
 
     // Step 5: Add a task with dependencies
     //

--- a/examples/02_fan_out.rs
+++ b/examples/02_fan_out.rs
@@ -55,7 +55,7 @@
 //!   Squared: 100
 //! ```
 
-use dagx::{task, DagRunner};
+use dagx::{task, DagRunner, TaskHandle};
 use futures::FutureExt;
 
 // Source task with a value field
@@ -131,13 +131,13 @@ async fn main() {
     let dag = DagRunner::new();
 
     // Single source task - constructed with ::new()
-    let source = dag.add_task(Source::new(10));
+    let source: TaskHandle<_> = dag.add_task(Source::new(10)).into();
 
     // Multiple downstream tasks consuming the same value
     // Each constructed differently to show flexibility
-    let plus_one = dag.add_task(AddOffset::new(1)).depends_on(&source);
-    let times_two = dag.add_task(Multiply::new(2)).depends_on(&source);
-    let squared = dag.add_task(Power { exponent: 2 }).depends_on(&source);
+    let plus_one = dag.add_task(AddOffset::new(1)).depends_on(source);
+    let times_two = dag.add_task(Multiply::new(2)).depends_on(source);
+    let squared = dag.add_task(Power { exponent: 2 }).depends_on(source);
 
     // Run the DAG
     println!("Running fan-out DAG...\n");

--- a/examples/03_fan_in.rs
+++ b/examples/03_fan_in.rs
@@ -130,7 +130,7 @@ async fn main() {
     // Single downstream task consuming all values
     let profile = dag
         .add_task(BuildProfile)
-        .depends_on((&name, &age, &city, &active));
+        .depends_on((name, age, city, active));
 
     // Run the DAG
     println!("Running fan-in DAG...\n");

--- a/examples/04_parallel_computation.rs
+++ b/examples/04_parallel_computation.rs
@@ -123,9 +123,7 @@ async fn main() -> DagResult<()> {
         let sum3 = dag.add_task(ComputeSum::new(501, 751, WORK_DELAY));
         let sum4 = dag.add_task(ComputeSum::new(751, 1001, WORK_DELAY));
 
-        let total = dag
-            .add_task(Aggregate)
-            .depends_on((&sum1, &sum2, &sum3, &sum4));
+        let total = dag.add_task(Aggregate).depends_on((sum1, sum2, sum3, sum4));
 
         dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 

--- a/examples/circuit_breaker.rs
+++ b/examples/circuit_breaker.rs
@@ -448,7 +448,7 @@ async fn main() {
 
         let fallback5 = dag
             .add_task(FallbackService::new("ServiceCall-5"))
-            .depends_on(&call5);
+            .depends_on(call5);
 
         dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
             .await

--- a/examples/complex_dag.rs
+++ b/examples/complex_dag.rs
@@ -184,8 +184,8 @@ async fn main() -> DagResult<()> {
     let source_b = dag.add_task(LoadData::new("B"));
 
     // Transform: Process each source (parallel)
-    let transform_a = dag.add_task(Transform::new(2)).depends_on(&source_a);
-    let transform_b = dag.add_task(Transform::new(3)).depends_on(&source_b);
+    let transform_a = dag.add_task(Transform::new(2)).depends_on(source_a);
+    let transform_b = dag.add_task(Transform::new(3)).depends_on(source_b);
 
     // Combine: Merge the transformed datasets
     let combined = dag

--- a/examples/conditional_workflow.rs
+++ b/examples/conditional_workflow.rs
@@ -128,9 +128,9 @@ async fn main() -> DagResult<()> {
     let processed3 = dag.add_task(ValidateAndDouble::new(20)); // Valid: 40
 
     // Categorize each result (also parallel, threshold = 25)
-    let cat1 = dag.add_task(Categorize::new(25)).depends_on(&processed1); // 20 < 25 = "low"
-    let cat2 = dag.add_task(Categorize::new(25)).depends_on(&processed2); // 0 = "invalid"
-    let cat3 = dag.add_task(Categorize::new(25)).depends_on(&processed3); // 40 >= 25 = "high"
+    let cat1 = dag.add_task(Categorize::new(25)).depends_on(processed1); // 20 < 25 = "low"
+    let cat2 = dag.add_task(Categorize::new(25)).depends_on(processed2); // 0 = "invalid"
+    let cat3 = dag.add_task(Categorize::new(25)).depends_on(processed3); // 40 >= 25 = "high"
 
     // Combine results
     let summary = dag

--- a/examples/data_pipeline.rs
+++ b/examples/data_pipeline.rs
@@ -191,15 +191,15 @@ async fn main() {
     // Stage 2: Data transformation (with stateful tasks)
     let transformed_1 = dag
         .add_task(DataTransformer::new(1.5))
-        .depends_on(&raw_value_1);
+        .depends_on(raw_value_1);
 
     let transformed_2 = dag
         .add_task(DataTransformer::new(2.0))
-        .depends_on(&raw_value_2);
+        .depends_on(raw_value_2);
 
     let transformed_3 = dag
         .add_task(DataTransformer::new(0.5))
-        .depends_on(&raw_value_3);
+        .depends_on(raw_value_3);
 
     // Stage 3: Statistical analysis (parallel operations on transformed data)
     let sum = dag

--- a/examples/debug_tracing.rs
+++ b/examples/debug_tracing.rs
@@ -398,7 +398,7 @@ async fn main() {
         // Aggregate traces
         let summary = dag
             .add_task(TraceAggregator::new(correlation_id))
-            .depends_on((&inventory, &payment, &shipping));
+            .depends_on((inventory, payment, shipping));
 
         // Run the DAG
         dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -214,7 +214,7 @@ async fn main() {
 
         let input = dag.add_task(StringSource("42"));
 
-        let parsed = dag.add_task(ParseInt).depends_on(&input);
+        let parsed = dag.add_task(ParseInt).depends_on(input);
 
         let validated = dag
             .add_task(ValidateRange { min: 0, max: 100 })
@@ -240,7 +240,7 @@ async fn main() {
 
         let input = dag.add_task(StringSource("not a number"));
 
-        let parsed = dag.add_task(ParseInt).depends_on(&input);
+        let parsed = dag.add_task(ParseInt).depends_on(input);
 
         let validated = dag
             .add_task(ValidateRange { min: 0, max: 100 })
@@ -266,7 +266,7 @@ async fn main() {
 
         let input = dag.add_task(StringSource("150"));
 
-        let parsed = dag.add_task(ParseInt).depends_on(&input);
+        let parsed = dag.add_task(ParseInt).depends_on(input);
 
         let validated = dag
             .add_task(ValidateRange { min: 0, max: 100 })
@@ -292,7 +292,7 @@ async fn main() {
 
         let input = dag.add_task(StringSource("invalid"));
 
-        let parsed = dag.add_task(ParseInt).depends_on(&input);
+        let parsed = dag.add_task(ParseInt).depends_on(input);
 
         let with_fallback = dag
             .add_task(WithFallback { fallback: 0 })

--- a/examples/large_dag.rs
+++ b/examples/large_dag.rs
@@ -192,7 +192,7 @@ async fn main() {
 
         // Verify a few results
         let sum: i32 = tasks
-            .iter()
+            .into_iter()
             .take(10)
             .map(|t| dag.get(t).unwrap())
             .fold(0i32, |acc, x| acc.wrapping_add(x));
@@ -208,7 +208,7 @@ async fn main() {
 
         // Create a deep chain by combining adjacent task pairs
         let tasks: Vec<_> = (0..100)
-            .map(|i| dag.add_task(Compute { value: i }))
+            .map(|i| dag.add_task(Compute { value: i }).into())
             .collect();
         let mut chain_tasks = vec![];
         for i in 0..99 {
@@ -246,7 +246,7 @@ async fn main() {
         // Process all levels reducing by combining pairs
         let mut level = 0;
         let mut layer: Vec<dagx::TaskHandle<i32>> =
-            current_level.iter().map(|b| b.into()).collect();
+            current_level.into_iter().map(|b| b.into()).collect();
 
         while layer.len() > 1 {
             level += 1;
@@ -291,7 +291,7 @@ async fn main() {
 
         // Layer 1: 50 source tasks
         let sources: Vec<_> = (0..50)
-            .map(|i| dag.add_task(Compute { value: i }))
+            .map(|i| dag.add_task(Compute { value: i }).into())
             .collect();
 
         // Layer 2: 50 tasks, each depends on all sources
@@ -361,11 +361,11 @@ async fn main() {
 
         // Verify results are accessible
         let i32_sum: i32 = small_tasks
-            .iter()
+            .into_iter()
             .map(|t| dag.get(t).unwrap())
             .fold(0i32, |acc, x| acc.wrapping_add(x));
         let string_count = string_tasks
-            .iter()
+            .into_iter()
             .map(|t| dag.get(t).unwrap().len())
             .sum::<usize>();
 

--- a/examples/parallelism_proof.rs
+++ b/examples/parallelism_proof.rs
@@ -93,7 +93,7 @@ async fn main() {
     let elapsed = start.elapsed();
 
     // Verify all tasks completed correctly
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task).unwrap(), i as u32);
     }
 

--- a/examples/tracing_example.rs
+++ b/examples/tracing_example.rs
@@ -87,7 +87,7 @@ async fn main() {
         let dag = DagRunner::new();
 
         // Layer 0: Source
-        let source = dag.add_task(Value(10));
+        let source = dag.add_task(Value(10)).into();
 
         // Layer 1: Two parallel computations
         let left = dag.add_task(Add).depends_on((&source, &source));
@@ -112,7 +112,7 @@ async fn main() {
 
         // Create a linear chain - each layer has only one task
         // This should trigger inline execution optimization
-        let a = dag.add_task(Value(1));
+        let a = dag.add_task(Value(1)).into();
         let b = dag.add_task(Add).depends_on((&a, &a));
         let c = dag.add_task(Multiply).depends_on((&b, &b));
         let d = dag.add_task(Add).depends_on((&c, &c));
@@ -132,10 +132,10 @@ async fn main() {
         let dag = DagRunner::new();
 
         // Layer 0: Multiple sources
-        let v1 = dag.add_task(Value(1));
-        let v2 = dag.add_task(Value(2));
-        let v3 = dag.add_task(Value(3));
-        let v4 = dag.add_task(Value(4));
+        let v1 = dag.add_task(Value(1)).into();
+        let v2 = dag.add_task(Value(2)).into();
+        let v3 = dag.add_task(Value(3)).into();
+        let v4 = dag.add_task(Value(4)).into();
 
         // Layer 1: Multiple parallel computations
         let sum12 = dag.add_task(Add).depends_on((&v1, &v2));

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -63,11 +63,11 @@ impl IsUnitType for () {}
 /// let b = dag.add_task(Multiplier::new(2));
 /// // b is TaskBuilder<_, Pending> until we call depends_on()
 ///
-/// let b = b.depends_on(&a);
+/// let b = b.depends_on(a);
 /// // Now b is a TaskHandle<i32>
 ///
 /// dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap();
-/// assert_eq!(dag.get(&b).unwrap(), 20);
+/// assert_eq!(dag.get(b).unwrap(), 20);
 /// # };
 /// ```
 pub struct TaskBuilder<'a, Tk: Task, Deps> {
@@ -118,14 +118,14 @@ impl<'a, Tk: Task, Deps> TaskBuilder<'a, Tk, Deps> {
     /// # async {
     /// let dag = DagRunner::new();
     ///
-    /// let x = dag.add_task(Value(2));
+    /// let x = dag.add_task(Value(2)).into();
     /// let y = dag.add_task(Value(3));
     ///
     /// // Single dependency
     /// let double = dag.add_task(Scale(2)).depends_on(&x);
     ///
     /// // Multiple dependencies: tuple form
-    /// let sum = dag.add_task(Add).depends_on((&x, &y));
+    /// let sum = dag.add_task(Add).depends_on((&x, y));
     ///
     /// dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap();
     /// # };
@@ -169,7 +169,3 @@ impl<'a, Tk: Task, Deps> TaskBuilder<'a, Tk, Deps> {
 
 #[cfg(test)]
 mod tests;
-
-// Note: We cannot safely implement AsRef<TaskHandle<Tk::Output>> for TaskBuilder<Tk, Deps>
-// because Handle is Copy and returning a reference to a temporary would be unsound.
-// Instead, users should use From/Into conversions or call .into() explicitly.

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -76,7 +76,7 @@ fn test_task_builder_depends_on_returns_handle() {
     let dag = DagRunner::new();
 
     let source = dag.add_task(TestTask { value: 10 });
-    let dependent = dag.add_task(TestTaskWithInput).depends_on(&source);
+    let dependent = dag.add_task(TestTaskWithInput).depends_on(source);
 
     // depends_on should return a TaskHandle
     let _handle: TaskHandle<i32> = dependent;
@@ -87,12 +87,12 @@ fn test_task_builder_chain() {
     let dag = DagRunner::new();
 
     // Test chaining multiple tasks
-    let t1 = dag.add_task(TestTask { value: 1 });
-    let t2 = dag.add_task(TestTaskWithInput).depends_on(&t1);
+    let t1 = dag.add_task(TestTask { value: 1 }).into();
+    let t2 = dag.add_task(TestTaskWithInput).depends_on(t1);
     let t3 = dag.add_task(TestTaskWithInput).depends_on(t2);
 
     // All should return TaskHandles
-    let _: TaskHandle<i32> = t1.into();
+    let _: TaskHandle<i32> = t1;
     let _: TaskHandle<i32> = t2;
     let _: TaskHandle<i32> = t3;
 }
@@ -115,7 +115,7 @@ fn test_multiple_dependencies() {
     let b = dag.add_task(TestTask { value: 20 });
 
     // Test multiple dependencies
-    let sum = dag.add_task(AddTask).depends_on((&a, &b));
+    let sum = dag.add_task(AddTask).depends_on((a, b));
 
     // Should return a TaskHandle
     let _: TaskHandle<i32> = sum;

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -11,52 +11,60 @@ use crate::builder::TaskBuilder;
 use crate::task::Task;
 use crate::types::{NodeId, TaskHandle};
 
+trait IntoNodeRef {
+    type Output;
+    fn into_node_ref(self) -> NodeId;
+}
+
+impl<T> IntoNodeRef for &TaskHandle<T> {
+    type Output = T;
+    fn into_node_ref(self) -> NodeId {
+        self.id
+    }
+}
+
+impl<T> IntoNodeRef for TaskHandle<T> {
+    type Output = T;
+    fn into_node_ref(self) -> NodeId {
+        self.id
+    }
+}
+
+impl<'runner, Tk: Task, Deps> IntoNodeRef for TaskBuilder<'runner, Tk, Deps> {
+    type Output = Tk::Output;
+
+    fn into_node_ref(self) -> NodeId {
+        self.id
+    }
+}
+
 pub(crate) trait DepsTuple<Input> {
-    fn to_node_ids(&self) -> Vec<NodeId>;
+    fn to_node_ids(self) -> Vec<NodeId>;
 }
 
 // Implementation for unit (no dependencies)
 impl DepsTuple<()> for () {
-    fn to_node_ids(&self) -> Vec<NodeId> {
+    fn to_node_ids(self) -> Vec<NodeId> {
         Vec::new()
     }
 }
 
 // Implementation for single dependency (all forms)
-impl<T> DepsTuple<T> for &TaskHandle<T> {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.id]
+impl<T> DepsTuple<T::Output> for T
+where
+    T: IntoNodeRef,
+{
+    fn to_node_ids(self) -> Vec<NodeId> {
+        vec![self.into_node_ref()]
     }
 }
 
-impl<T> DepsTuple<T> for TaskHandle<T> {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.id]
-    }
-}
-
-impl<T> DepsTuple<T> for (&TaskHandle<T>,) {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.0.id]
-    }
-}
-
-impl<T> DepsTuple<T> for (TaskHandle<T>,) {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.0.id]
-    }
-}
-
-// Support for &TaskBuilder
-impl<'a, Tk: Task, Deps> DepsTuple<Tk::Output> for &TaskBuilder<'a, Tk, Deps> {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.id]
-    }
-}
-
-impl<'a, Tk: Task, Deps> DepsTuple<Tk::Output> for (&TaskBuilder<'a, Tk, Deps>,) {
-    fn to_node_ids(&self) -> Vec<NodeId> {
-        vec![self.0.id]
+impl<T> DepsTuple<T::Output> for (T,)
+where
+    T: IntoNodeRef,
+{
+    fn to_node_ids(self) -> Vec<NodeId> {
+        vec![self.0.into_node_ref()]
     }
 }
 
@@ -64,10 +72,6 @@ impl<'a, Tk: Task, Deps> DepsTuple<Tk::Output> for (&TaskBuilder<'a, Tk, Deps>,)
 ///
 /// This macro exists because Rust lacks variadic generics - we need separate implementations
 /// for each tuple size.
-///
-/// For each tuple size, generates two implementations:
-/// - `(&TaskHandle<A>, &TaskHandle<B>, ...)` → `DepsTuple<(A, B, ...)>`
-/// - `(&TaskBuilder<TkA, _>, &TaskBuilder<TkB, _>, ...)` → `DepsTuple<(TkA::Output, TkB::Output, ...)>`
 ///
 /// This allows flexible dependency specification:
 /// ```ignore
@@ -78,37 +82,27 @@ impl<'a, Tk: Task, Deps> DepsTuple<Tk::Output> for (&TaskBuilder<'a, Tk, Deps>,)
 /// task.depends_on((&dag.add_task(TaskA), &dag.add_task(TaskB)))
 /// ```
 macro_rules! impl_deps_tuple {
-    ($($T:ident : $Tk:ident : $D:ident),+) => {
-        // For &TaskHandle tuples
-        impl<$($T),+> DepsTuple<($($T,)+)> for ($(&TaskHandle<$T>,)+) {
+    ($($T:ident),+) => {
+        // For tuples of any combination of &TaskHandle, TaskHandle, and TaskBuilder
+        impl<$($T: IntoNodeRef),+> DepsTuple<($($T::Output,)+)> for ($($T,)+) {
             #[allow(non_snake_case)]
-            fn to_node_ids(&self) -> Vec<NodeId> {
+            fn to_node_ids(self) -> Vec<NodeId> {
                 let ($($T,)+) = self;
-                vec![$($T.id,)+]
-            }
-        }
-
-        // For &TaskBuilder tuples
-        impl<'a, $($Tk: Task, $D),+> DepsTuple<($($Tk::Output,)+)> for ($(&TaskBuilder<'a, $Tk, $D>,)+) {
-            #[allow(non_snake_case)]
-            fn to_node_ids(&self) -> Vec<NodeId> {
-                let ($($T,)+) = self;
-                vec![$($T.id,)+]
+                vec![$($T.into_node_ref(),)+]
             }
         }
     };
 }
 
 // Generate DepsTuple implementations for tuples of size 2-8.
-// Each invocation generates 2 implementations (TaskHandle refs and TaskBuilder refs).
 // Supporting up to 8 elements covers the vast majority of use cases.
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC, D:TkD:DD);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC, D:TkD:DD, E:TkE:DE);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC, D:TkD:DD, E:TkE:DE, F:TkF:DF);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC, D:TkD:DD, E:TkE:DE, F:TkF:DF, G:TkG:DG);
-impl_deps_tuple!(A:TkA:DA, B:TkB:DB, C:TkC:DC, D:TkD:DD, E:TkE:DE, F:TkF:DF, G:TkG:DG, H:TkH:DH);
+impl_deps_tuple!(T1, T2);
+impl_deps_tuple!(T1, T2, T3);
+impl_deps_tuple!(T1, T2, T3, T4);
+impl_deps_tuple!(T1, T2, T3, T4, T5);
+impl_deps_tuple!(T1, T2, T3, T4, T5, T6);
+impl_deps_tuple!(T1, T2, T3, T4, T5, T6, T7);
+impl_deps_tuple!(T1, T2, T3, T4, T5, T6, T7, T8);
 
 #[cfg(test)]
 mod tests;

--- a/src/deps/tests.rs
+++ b/src/deps/tests.rs
@@ -91,12 +91,13 @@ fn test_deps_tuple_task_builder_ref() {
     // Test lines 51-55 in deps.rs - &TaskBuilder
     let dag = DagRunner::new();
     let builder = dag.add_task(TestTask { value: 42 });
+    let builder_id = builder.id;
 
     // We need to test the DepsTuple implementation directly
     // The builder has an id field we can check
-    let node_ids = (&builder).to_node_ids();
+    let node_ids = builder.to_node_ids();
     assert_eq!(node_ids.len(), 1);
-    assert_eq!(node_ids[0], builder.id);
+    assert_eq!(node_ids[0], builder_id);
 }
 
 #[test]
@@ -104,10 +105,11 @@ fn test_deps_tuple_task_builder_tuple() {
     // Test lines 57-61 in deps.rs - (&TaskBuilder,)
     let dag = DagRunner::new();
     let builder = dag.add_task(TestTask { value: 100 });
+    let builder_id = builder.id;
 
-    let node_ids = (&builder,).to_node_ids();
+    let node_ids = (builder,).to_node_ids();
     assert_eq!(node_ids.len(), 1);
-    assert_eq!(node_ids[0], builder.id);
+    assert_eq!(node_ids[0], builder_id);
 }
 
 #[test]
@@ -145,21 +147,18 @@ fn test_deps_tuple_multiple_builders() {
     // Test macro-generated implementations for multiple builders
     let dag = DagRunner::new();
     let builder1 = dag.add_task(TestTask { value: 10 });
+    let builder1_id = builder1.id;
     let builder2 = dag.add_task(TestTask { value: 20 });
+    let builder2_id = builder2.id;
     let builder3 = dag.add_task(TestTask { value: 30 });
-
-    // Test 2-tuple of builders
-    let node_ids = (&builder1, &builder2).to_node_ids();
-    assert_eq!(node_ids.len(), 2);
-    assert_eq!(node_ids[0], builder1.id);
-    assert_eq!(node_ids[1], builder2.id);
+    let builder3_id = builder3.id;
 
     // Test 3-tuple of builders
-    let node_ids = (&builder1, &builder2, &builder3).to_node_ids();
+    let node_ids = (builder1, builder2, builder3).to_node_ids();
     assert_eq!(node_ids.len(), 3);
-    assert_eq!(node_ids[0], builder1.id);
-    assert_eq!(node_ids[1], builder2.id);
-    assert_eq!(node_ids[2], builder3.id);
+    assert_eq!(node_ids[0], builder1_id);
+    assert_eq!(node_ids[1], builder2_id);
+    assert_eq!(node_ids[2], builder3_id);
 }
 
 #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -83,7 +83,7 @@ impl<'a> Drop for RunGuard<'a> {
 /// // Construct instances using ::new() pattern
 /// let x = dag.add_task(LoadValue::new(2));
 /// let y = dag.add_task(LoadValue::new(3));
-/// let sum = dag.add_task(Add).depends_on((&x, &y));
+/// let sum = dag.add_task(Add).depends_on((x, y));
 ///
 /// dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap();
 ///
@@ -190,10 +190,10 @@ impl DagRunner {
     /// let base = dag.add_task(LoadValue::new(10));
     ///
     /// // Construct task with offset of 1
-    /// let inc = dag.add_task(AddOffset::new(1)).depends_on(&base);
+    /// let inc = dag.add_task(AddOffset::new(1)).depends_on(base);
     ///
     /// dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap();
-    /// assert_eq!(dag.get(&inc).unwrap(), 11);
+    /// assert_eq!(dag.get(inc).unwrap(), 11);
     /// # };
     /// ```
     pub fn add_task<Tk>(&self, task: Tk) -> TaskBuilder<'_, Tk, Pending>
@@ -278,7 +278,7 @@ impl DagRunner {
     ///
     /// let a = dag.add_task(Value(1));
     /// let b = dag.add_task(Value(2));
-    /// let sum = dag.add_task(Add).depends_on((&a, &b));
+    /// let sum = dag.add_task(Add).depends_on((a, b));
     ///
     /// dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await.unwrap(); // Executes all tasks
     /// # };

--- a/src/runner/tests.rs
+++ b/src/runner/tests.rs
@@ -190,16 +190,16 @@ async fn test_multiple_get_calls() {
     init_tracing();
     // Test that get() can be called multiple times for the same handle
     let dag = DagRunner::new();
-    let handle = dag.add_task(TestTask { value: 100 });
+    let handle: TaskHandle<_> = dag.add_task(TestTask { value: 100 }).into();
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
         .unwrap();
 
     // Multiple get calls should all return the same value
-    let result1 = dag.get(&handle).unwrap();
-    let result2 = dag.get(&handle).unwrap();
-    let result3 = dag.get(&handle).unwrap();
+    let result1 = dag.get(handle).unwrap();
+    let result2 = dag.get(handle).unwrap();
+    let result3 = dag.get(handle).unwrap();
 
     assert_eq!(result1, 100);
     assert_eq!(result2, 100);
@@ -264,11 +264,11 @@ async fn test_task_panic_in_multi_task_layer() {
     }
 
     let dag = DagRunner::new();
-    let source = dag.add_task(Source);
+    let source: TaskHandle<_> = dag.add_task(Source).into();
 
     // Create two tasks in the same layer - one panics, one doesn't
-    let _panic_task = dag.add_task(PanicTask).depends_on(&source);
-    let _good_task = dag.add_task(GoodTask).depends_on(&source);
+    let _panic_task = dag.add_task(PanicTask).depends_on(source);
+    let _good_task = dag.add_task(GoodTask).depends_on(source);
 
     // Run the DAG - the panic should be caught
     let result = dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await;

--- a/src/types.rs
+++ b/src/types.rs
@@ -75,18 +75,6 @@ where
     }
 }
 
-impl<'a, Tk: Task, Deps> From<&TaskBuilder<'a, Tk, Deps>> for TaskHandle<Tk::Output>
-where
-    Tk::Input: IsUnitType,
-{
-    fn from(node: &TaskBuilder<'a, Tk, Deps>) -> Self {
-        TaskHandle {
-            id: node.id,
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
 // TaskHandle can be converted from &TaskHandle (for .get() calls)
 impl<T> From<&TaskHandle<T>> for TaskHandle<T> {
     fn from(handle: &TaskHandle<T>) -> Self {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -147,25 +147,3 @@ fn test_task_handle_ref_from_conversion() {
     assert_eq!(converted.id.0, 123);
     assert_eq!(handle.id, converted.id);
 }
-
-#[test]
-fn test_task_builder_ref_from_conversion() {
-    use crate::runner::DagRunner;
-
-    // Test From<&TaskBuilder> for TaskHandle (line 77-87, specifically line 83)
-    struct SimpleTask2;
-    #[crate::task]
-    impl SimpleTask2 {
-        async fn run(&self) -> String {
-            "test".to_string()
-        }
-    }
-
-    let dag = DagRunner::new();
-    let builder = dag.add_task(SimpleTask2);
-    let builder_id = builder.id;
-
-    // This conversion uses the From<&TaskBuilder> implementation
-    let handle: TaskHandle<String> = (&builder).into();
-    assert_eq!(handle.id, builder_id);
-}

--- a/tests/boundaries/deep_chains.rs
+++ b/tests/boundaries/deep_chains.rs
@@ -12,7 +12,7 @@ async fn test_1000_level_deep_chain() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let first = dag.add_task(task_fn(|_: ()| async { 0 }));
-    let mut current = (&first).into(); // Convert to TaskHandle
+    let mut current = first.into(); // Convert to TaskHandle
 
     for _i in 1..1000 {
         current = dag
@@ -32,7 +32,7 @@ async fn test_deep_chain_with_branches() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let first = dag.add_task(task_fn(|_: ()| async { 0 }));
-    let mut main_chain: dagx::TaskHandle<i32> = (&first).into();
+    let mut main_chain: dagx::TaskHandle<i32> = first.into();
     let mut branches = Vec::new();
 
     for i in 1..500 {
@@ -72,7 +72,7 @@ async fn test_multiple_parallel_deep_chains() -> DagResult<()> {
 
     for chain_id in 0..8 {
         let first = dag.add_task(task_fn(move |_: ()| async move { chain_id * 1000 }));
-        let mut current: dagx::TaskHandle<i32> = (&first).into();
+        let mut current: dagx::TaskHandle<i32> = first.into();
 
         for _ in 0..500 {
             current = dag
@@ -136,7 +136,7 @@ async fn test_deep_chain_execution_order() -> DagResult<()> {
             }
         }
     }));
-    let mut current: dagx::TaskHandle<i32> = (&first).into();
+    let mut current: dagx::TaskHandle<i32> = first.into();
 
     for expected in 1..100 {
         current = dag
@@ -169,7 +169,7 @@ async fn test_deep_binary_tree() -> DagResult<()> {
     fn build_tree(dag: &DagRunner, depth: usize, value: i32) -> dagx::TaskHandle<i32> {
         if depth == 0 {
             let task = dag.add_task(task_fn(move |_: ()| async move { value }));
-            (&task).into() // Convert TaskBuilder to TaskHandle
+            task.into() // Convert TaskBuilder to TaskHandle
         } else {
             let left = build_tree(dag, depth - 1, value * 2);
             let right = build_tree(dag, depth - 1, value * 2 + 1);
@@ -199,8 +199,8 @@ async fn test_fibonacci_chain() -> DagResult<()> {
     let f0_builder = dag.add_task(task_fn(|_: ()| async { 0i64 }));
     let f1_builder = dag.add_task(task_fn(|_: ()| async { 1i64 }));
 
-    let mut prev2: dagx::TaskHandle<i64> = (&f0_builder).into();
-    let mut prev1: dagx::TaskHandle<i64> = (&f1_builder).into();
+    let mut prev2: dagx::TaskHandle<i64> = f0_builder.into();
+    let mut prev1: dagx::TaskHandle<i64> = f1_builder.into();
 
     for _ in 2..50 {
         let next = dag
@@ -226,7 +226,7 @@ async fn test_deep_chain_with_accumulator() -> DagResult<()> {
 
     // Use a simpler accumulation pattern - just sum
     let first = dag.add_task(task_fn(|_: ()| async { 0i64 }));
-    let mut current: dagx::TaskHandle<i64> = (&first).into();
+    let mut current: dagx::TaskHandle<i64> = first.into();
 
     for i in 1..=200 {
         current = dag
@@ -250,8 +250,8 @@ async fn test_zigzag_dependencies() -> DagResult<()> {
     let a_first = dag.add_task(task_fn(|_: ()| async { 1 }));
     let b_first = dag.add_task(task_fn(|_: ()| async { 2 }));
 
-    let mut chain_a: dagx::TaskHandle<i32> = (&a_first).into();
-    let mut chain_b: dagx::TaskHandle<i32> = (&b_first).into();
+    let mut chain_a: dagx::TaskHandle<i32> = a_first.into();
+    let mut chain_b: dagx::TaskHandle<i32> = b_first.into();
 
     for i in 0..100 {
         if i % 2 == 0 {
@@ -287,7 +287,7 @@ async fn test_10000_level_chain_stress() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let first = dag.add_task(task_fn(|_: ()| async { 0u64 }));
-    let mut current: dagx::TaskHandle<u64> = (&first).into();
+    let mut current: dagx::TaskHandle<u64> = first.into();
 
     for _ in 1..10_000 {
         current = dag

--- a/tests/boundaries/zero_tasks.rs
+++ b/tests/boundaries/zero_tasks.rs
@@ -64,7 +64,7 @@ async fn test_zero_sized_type_task() -> DagResult<()> {
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
-    assert_eq!(dag.get(&task)?, ZeroSized);
+    assert_eq!(dag.get(task)?, ZeroSized);
     Ok(())
 }
 
@@ -91,7 +91,7 @@ async fn test_dag_with_only_source_tasks() -> DagResult<()> {
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task)?, i);
     }
 
@@ -155,7 +155,7 @@ async fn test_dag_with_never_type_simulation() -> DagResult<()> {
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
-    assert_eq!(dag.get(&task)?, Ok(42));
+    assert_eq!(dag.get(task)?, Ok(42));
     Ok(())
 }
 

--- a/tests/dependencies/tuples.rs
+++ b/tests/dependencies/tuples.rs
@@ -12,7 +12,7 @@ async fn test_two_dependencies() -> DagResult<()> {
     let b = dag.add_task(task_fn(|_: ()| async { 20 }));
     let sum = dag
         .add_task(task_fn(|(x, y): (i32, i32)| async move { x + y }))
-        .depends_on((&a, &b));
+        .depends_on((a, b));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
@@ -31,7 +31,7 @@ async fn test_three_dependencies() -> DagResult<()> {
         .add_task(task_fn(
             |(x, y, z): (i32, i32, i32)| async move { x + y + z },
         ))
-        .depends_on((&a, &b, &c));
+        .depends_on((a, b, c));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
@@ -44,7 +44,7 @@ async fn test_four_dependencies() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let deps: Vec<_> = (1..=4)
-        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
+        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })).into())
         .collect();
 
     let sum = dag
@@ -64,7 +64,7 @@ async fn test_five_dependencies() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let deps: Vec<_> = (1..=5)
-        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
+        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })).into())
         .collect();
 
     let sum = dag
@@ -84,7 +84,7 @@ async fn test_six_dependencies() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let deps: Vec<_> = (1..=6)
-        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
+        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })).into())
         .collect();
 
     let sum = dag.add_task(task_fn(
@@ -106,7 +106,7 @@ async fn test_seven_dependencies() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let deps: Vec<_> = (1..=7)
-        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
+        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })).into())
         .collect();
 
     let sum = dag
@@ -130,7 +130,7 @@ async fn test_eight_dependencies() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let deps: Vec<_> = (1..=8)
-        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
+        .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })).into())
         .collect();
 
     let sum = dag

--- a/tests/execution/integration.rs
+++ b/tests/execution/integration.rs
@@ -59,9 +59,9 @@ async fn integration_test_etl_pipeline() -> DagResult<()> {
     let source3 = dag.add_task(LoadValue::new(30));
 
     // Transform: Process each source
-    let transform1 = dag.add_task(Multiply::new(2)).depends_on(&source1);
-    let transform2 = dag.add_task(Multiply::new(3)).depends_on(&source2);
-    let transform3 = dag.add_task(Multiply::new(4)).depends_on(&source3);
+    let transform1 = dag.add_task(Multiply::new(2)).depends_on(source1);
+    let transform2 = dag.add_task(Multiply::new(3)).depends_on(source2);
+    let transform3 = dag.add_task(Multiply::new(4)).depends_on(source3);
 
     // Load: Aggregate results
     let combine12 = dag.add_task(Add).depends_on((&transform1, &transform2));
@@ -115,9 +115,9 @@ async fn integration_test_multiple_sinks() -> DagResult<()> {
     let source = dag.add_task(LoadValue::new(10));
 
     // Multiple independent branches
-    let branch1 = dag.add_task(Multiply::new(2)).depends_on(&source);
-    let branch2 = dag.add_task(Multiply::new(3)).depends_on(&source);
-    let branch3 = dag.add_task(Multiply::new(4)).depends_on(&source);
+    let branch1 = dag.add_task(Multiply::new(2)).depends_on(source);
+    let branch2 = dag.add_task(Multiply::new(3)).depends_on(source);
+    let branch3 = dag.add_task(Multiply::new(4)).depends_on(source);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
@@ -136,8 +136,8 @@ async fn integration_test_diamond_cascade() -> DagResult<()> {
 
     // Diamond 1
     let source1 = dag.add_task(LoadValue::new(10));
-    let left1 = dag.add_task(Multiply::new(2)).depends_on(&source1);
-    let right1 = dag.add_task(Multiply::new(3)).depends_on(&source1);
+    let left1 = dag.add_task(Multiply::new(2)).depends_on(source1);
+    let right1 = dag.add_task(Multiply::new(3)).depends_on(source1);
     let sink1 = dag.add_task(Add).depends_on((&left1, &right1));
 
     // Diamond 2 (depends on Diamond 1)
@@ -193,7 +193,7 @@ async fn integration_test_error_recovery() -> DagResult<()> {
     let dag = DagRunner::new();
 
     let source = dag.add_task(LoadValue::new(42));
-    let transform = dag.add_task(Multiply::new(2)).depends_on(&source);
+    let transform = dag.add_task(Multiply::new(2)).depends_on(source);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
@@ -248,9 +248,9 @@ async fn integration_test_reused_values() -> DagResult<()> {
     let source = dag.add_task(LoadValue::new(100));
 
     // Use source in multiple different ways
-    let double = dag.add_task(Multiply::new(2)).depends_on(&source);
-    let triple = dag.add_task(Multiply::new(3)).depends_on(&source);
-    let quadruple = dag.add_task(Multiply::new(4)).depends_on(&source);
+    let double = dag.add_task(Multiply::new(2)).depends_on(source);
+    let triple = dag.add_task(Multiply::new(3)).depends_on(source);
+    let quadruple = dag.add_task(Multiply::new(4)).depends_on(source);
 
     // Combine some of the results
     let combined = dag.add_task(Add).depends_on((&double, &triple));
@@ -328,7 +328,7 @@ async fn integration_test_parallel_vs_sequential_timing() -> DagResult<()> {
             sleep(sleep_duration).await;
             x + 1
         }))
-        .depends_on(&parallel_tasks[0]);
+        .depends_on(parallel_tasks[0]);
 
     let seq2 = dag
         .add_task(task_fn(move |x: i32| async move {

--- a/tests/execution/results.rs
+++ b/tests/execution/results.rs
@@ -85,7 +85,7 @@ async fn test_stateful_tasks() {
     let dag = DagRunner::new();
 
     let input = dag.add_task(task_fn(|_: ()| async { 5 }));
-    let counter = dag.add_task(Counter::new(10)).depends_on(&input);
+    let counter = dag.add_task(Counter::new(10)).depends_on(input);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -105,7 +105,7 @@ async fn test_task_fn_with_captured_state() {
     let base = dag.add_task(task_fn(|_: ()| async { 5 }));
     let scaled = dag
         .add_task(task_fn(move |x: i32| async move { x * multiplier }))
-        .depends_on(&base);
+        .depends_on(base);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await

--- a/tests/parallelism/proof.rs
+++ b/tests/parallelism/proof.rs
@@ -29,7 +29,7 @@ async fn test_parallelism_proof_1000_tasks() -> DagResult<()> {
     let elapsed = start.elapsed();
 
     // Verify all tasks completed
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task)?, i as u32);
     }
 

--- a/tests/parallelism/spawning.rs
+++ b/tests/parallelism/spawning.rs
@@ -35,7 +35,7 @@ async fn test_spawner_actually_spawns_tasks() -> DagResult<()> {
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
     // Verify all tasks were spawned
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task)?, i as i32);
     }
 
@@ -81,7 +81,7 @@ async fn test_tasks_not_running_inline() -> DagResult<()> {
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 
     // Verify results
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task)?, i as i32);
     }
 

--- a/tests/patterns/grid.rs
+++ b/tests/patterns/grid.rs
@@ -15,10 +15,10 @@ async fn test_2d_grid_pattern() -> DagResult<()> {
     #[allow(clippy::needless_range_loop)]
     for i in 0..4 {
         let task = dag.add_task(task_fn(move |_: ()| async move { i as i32 }));
-        grid[0][i] = Some((&task).into());
+        grid[0][i] = Some(task.into());
         if i > 0 {
             let task = dag.add_task(task_fn(move |_: ()| async move { i as i32 * 10 }));
-            grid[i][0] = Some((&task).into());
+            grid[i][0] = Some(task.into());
         }
     }
 
@@ -55,7 +55,7 @@ async fn test_3d_grid_pattern() -> DagResult<()> {
 
     // Initialize origin
     let origin = dag.add_task(task_fn(|_: ()| async { 1 }));
-    grid[0][0][0] = Some((&origin).into());
+    grid[0][0][0] = Some(origin.into());
 
     // Fill the 3D grid
     for x in 0..size {
@@ -77,7 +77,7 @@ async fn test_3d_grid_pattern() -> DagResult<()> {
                 let task_handle: dagx::TaskHandle<usize> = match deps.len() {
                     0 => {
                         let t = dag.add_task(task_fn(move |_: ()| async move { x + y + z }));
-                        (&t).into()
+                        t.into()
                     }
                     1 => dag
                         .add_task(task_fn(move |prev: usize| async move { prev + 1 }))
@@ -121,7 +121,7 @@ async fn test_hexagonal_grid() -> DagResult<()> {
 
     // Center hex
     let center_builder = dag.add_task(task_fn(|_: ()| async { 100 }));
-    let center: dagx::TaskHandle<i32> = (&center_builder).into();
+    let center: dagx::TaskHandle<i32> = center_builder.into();
     hex_grid.insert((0, 0), center);
 
     // Ring 1 (6 hexes around center)
@@ -168,7 +168,7 @@ async fn test_hexagonal_grid() -> DagResult<()> {
                 .depends_on(neighbors[0])
         } else {
             let t = dag.add_task(task_fn(move |_: ()| async move { q + r }));
-            (&t).into()
+            t.into()
         };
 
         hex_grid.insert((q, r), task);
@@ -194,7 +194,7 @@ async fn test_toroidal_grid() -> DagResult<()> {
     for i in 0..SIZE {
         for j in 0..SIZE {
             let task = dag.add_task(task_fn(move |_: ()| async move { (i * SIZE + j) as i32 }));
-            grid[i][j] = Some((&task).into());
+            grid[i][j] = Some(task.into());
         }
     }
 

--- a/tests/performance/memory.rs
+++ b/tests/performance/memory.rs
@@ -14,7 +14,7 @@ async fn test_memory_usage_10000_nodes() {
     let before_build = memory_usage_hint();
 
     // Create 10,000 nodes
-    let tasks: Vec<_> = (0..10_000)
+    let mut tasks: Vec<_> = (0..10_000)
         .map(|i| dag.add_task(task_fn(move |_: ()| async move { i })))
         .collect();
 
@@ -34,8 +34,8 @@ async fn test_memory_usage_10000_nodes() {
     println!("Additional memory for execution: ~{} bytes", exec_memory);
 
     // Verify some results
-    assert_eq!(dag.get(&tasks[0]).unwrap(), 0);
-    assert_eq!(dag.get(&tasks[9999]).unwrap(), 9999);
+    assert_eq!(dag.get(tasks.swap_remove(9999)).unwrap(), 9999);
+    assert_eq!(dag.get(tasks.swap_remove(0)).unwrap(), 0);
 
     // Memory should be reasonable (< 100MB for 10k simple nodes)
     assert!(

--- a/tests/performance/stress.rs
+++ b/tests/performance/stress.rs
@@ -13,7 +13,7 @@ async fn test_deep_chain_100_levels() {
     // Create a chain 100 levels deep
     let start = Instant::now();
     let first = dag.add_task(task_fn(|_: ()| async { 0 }));
-    let mut handles = vec![(&first).into()];
+    let mut handles = vec![first.into()];
 
     for _ in 1..=100 {
         let next = dag
@@ -52,7 +52,7 @@ async fn test_stress_mixed_patterns() {
     for i in 0..10 {
         // Linear chains
         let first = dag.add_task(task_fn(move |_: ()| async move { i * 1000 }));
-        let mut chain_handles = vec![(&first).into()];
+        let mut chain_handles = vec![first.into()];
         for j in 1..10 {
             let next = dag
                 .add_task(task_fn(move |x: i32| async move { x + j }))
@@ -63,7 +63,7 @@ async fn test_stress_mixed_patterns() {
 
         // Diamonds
         let source = dag.add_task(task_fn(move |_: ()| async move { i * 100 }));
-        let source_handle: dagx::TaskHandle<i32> = (&source).into();
+        let source_handle: dagx::TaskHandle<i32> = source.into();
         let left = dag
             .add_task(task_fn(|x: i32| async move { x * 2 }))
             .depends_on(source_handle);
@@ -77,7 +77,7 @@ async fn test_stress_mixed_patterns() {
 
         // Fan-outs
         let hub = dag.add_task(task_fn(move |_: ()| async move { i }));
-        let hub_handle: dagx::TaskHandle<i32> = (&hub).into();
+        let hub_handle: dagx::TaskHandle<i32> = hub.into();
         for j in 0..5 {
             let fan = dag
                 .add_task(task_fn(move |x: i32| async move { x + j * 10 }))

--- a/tests/runtimes/async_std.rs
+++ b/tests/runtimes/async_std.rs
@@ -25,7 +25,7 @@ async fn test_basic_dag_async_std() {
 
     let x = dag.add_task(Value(2));
     let y = dag.add_task(Value(3));
-    let sum = dag.add_task(Add).depends_on((&x, &y));
+    let sum = dag.add_task(Add).depends_on((x, y));
 
     dag.run(async_std::task::spawn).await.unwrap();
 
@@ -42,7 +42,7 @@ async fn test_parallel_execution_async_std() {
 
     dag.run(async_std::task::spawn).await.unwrap();
 
-    for (i, task) in tasks.iter().enumerate() {
+    for (i, task) in tasks.into_iter().enumerate() {
         assert_eq!(dag.get(task).unwrap(), i * 2);
     }
 }
@@ -53,7 +53,7 @@ async fn test_complex_dependencies_async_std() {
 
     let a = dag.add_task(Value(10));
     let b = dag.add_task(Value(20));
-    let sum = dag.add_task(Add).depends_on((&a, &b));
+    let sum = dag.add_task(Add).depends_on((a, b));
     let double = dag
         .add_task(task_fn(|x: i32| async move { x * 2 }))
         .depends_on(sum);

--- a/tests/runtimes/compatibility.rs
+++ b/tests/runtimes/compatibility.rs
@@ -25,7 +25,7 @@ async fn runtime_integration_tokio() -> DagResult<()> {
 
     let a = dag.add_task(Value(10));
     let b = dag.add_task(Value(20));
-    let sum = dag.add_task(Add).depends_on((&a, &b));
+    let sum = dag.add_task(Add).depends_on((a, b));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap)).await?;
 

--- a/tests/runtimes/smol.rs
+++ b/tests/runtimes/smol.rs
@@ -26,7 +26,7 @@ fn test_basic_dag_smol() {
 
         let x = dag.add_task(Value(2));
         let y = dag.add_task(Value(3));
-        let sum = dag.add_task(Add).depends_on((&x, &y));
+        let sum = dag.add_task(Add).depends_on((x, y));
 
         dag.run(smol::spawn).await.unwrap();
 
@@ -45,7 +45,7 @@ fn test_parallel_execution_smol() {
 
         dag.run(smol::spawn).await.unwrap();
 
-        for (i, task) in tasks.iter().enumerate() {
+        for (i, task) in tasks.into_iter().enumerate() {
             assert_eq!(dag.get(task).unwrap(), i * 2);
         }
     });
@@ -58,7 +58,7 @@ fn test_complex_dependencies_smol() {
 
         let a = dag.add_task(Value(10));
         let b = dag.add_task(Value(20));
-        let sum = dag.add_task(Add).depends_on((&a, &b));
+        let sum = dag.add_task(Add).depends_on((a, b));
         let double = dag
             .add_task(task_fn(|x: i32| async move { x * 2 }))
             .depends_on(sum);

--- a/tests/task_patterns/combined.rs
+++ b/tests/task_patterns/combined.rs
@@ -45,7 +45,7 @@ async fn test_all_three_task_patterns() {
     let y = dag.add_task(task_fn(|_: ()| async { 3 }));
 
     // Pattern 1: Stateless addition
-    let sum = dag.add_task(StatelessAdd).depends_on((&x, &y)); // 5 + 3 = 8
+    let sum = dag.add_task(StatelessAdd).depends_on((x, y)); // 5 + 3 = 8
 
     // Pattern 2: Read-only multiplication
     let doubled = dag.add_task(ReadOnlyMultiplier(2)).depends_on(sum); // 8 * 2 = 16
@@ -102,9 +102,9 @@ async fn test_parallel_execution() {
 
     // All three tasks should have run
     assert_eq!(counter.load(Ordering::SeqCst), 3);
-    assert_eq!(dag.get(&t1).unwrap(), 1);
-    assert_eq!(dag.get(&t2).unwrap(), 2);
-    assert_eq!(dag.get(&t3).unwrap(), 3);
+    assert_eq!(dag.get(t1).unwrap(), 1);
+    assert_eq!(dag.get(t2).unwrap(), 2);
+    assert_eq!(dag.get(t3).unwrap(), 3);
 }
 
 #[tokio::test]
@@ -115,7 +115,7 @@ async fn test_task_fn_with_captured_state() {
     let base = dag.add_task(task_fn(|_: ()| async { 5 }));
     let scaled = dag
         .add_task(task_fn(move |x: i32| async move { x * multiplier }))
-        .depends_on(&base);
+        .depends_on(base);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await

--- a/tests/task_patterns/readonly.rs
+++ b/tests/task_patterns/readonly.rs
@@ -55,7 +55,7 @@ async fn test_readonly_state_with_input() {
     let dag = DagRunner::new();
 
     let input = dag.add_task(task_fn(|_: ()| async { 5 }));
-    let result = dag.add_task(ReadOnlyMultiplier(7)).depends_on(&input);
+    let result = dag.add_task(ReadOnlyMultiplier(7)).depends_on(input);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -76,13 +76,13 @@ async fn test_readonly_state_multiple_uses() {
         offset: 5,
     };
 
-    let result1 = dag.add_task(config).depends_on(&input1);
+    let result1 = dag.add_task(config).depends_on(input1);
     // Note: Can't reuse config because it was moved, so create another
     let config2 = ReadOnlyConfig {
         multiplier: 3,
         offset: 5,
     };
-    let result2 = dag.add_task(config2).depends_on(&input2);
+    let result2 = dag.add_task(config2).depends_on(input2);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await

--- a/tests/tracing/with_tracing.rs
+++ b/tests/tracing/with_tracing.rs
@@ -43,7 +43,7 @@ async fn test_tracing_with_subscriber() {
 
     let a = dag.add_task(Value(2));
     let b = dag.add_task(Value(3));
-    let sum = dag.add_task(Add).depends_on((&a, &b));
+    let sum = dag.add_task(Add).depends_on((a, b));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -63,7 +63,7 @@ async fn test_tracing_with_complex_dag() {
     let dag = DagRunner::new();
 
     // Create a diamond pattern
-    let source = dag.add_task(Value(10));
+    let source = dag.add_task(Value(10)).into();
     let left = dag.add_task(Add).depends_on((&source, &source));
     let right = dag.add_task(Multiply).depends_on((&source, &source));
     let sink = dag.add_task(Add).depends_on((&left, &right));
@@ -90,7 +90,7 @@ async fn test_tracing_inline_execution() {
     let dag = DagRunner::new();
 
     // Create a linear chain (should trigger inline execution)
-    let a = dag.add_task(Value(1));
+    let a = dag.add_task(Value(1)).into();
     let b = dag.add_task(Add).depends_on((&a, &a));
     let c = dag.add_task(Multiply).depends_on((&b, &b));
 
@@ -118,12 +118,12 @@ async fn test_tracing_multiple_layers() {
 
     // Layer 0
     let v1 = dag.add_task(Value(1));
-    let v2 = dag.add_task(Value(2));
+    let v2 = dag.add_task(Value(2)).into();
     let v3 = dag.add_task(Value(3));
 
     // Layer 1
-    let sum12 = dag.add_task(Add).depends_on((&v1, &v2));
-    let mul23 = dag.add_task(Multiply).depends_on((&v2, &v3));
+    let sum12 = dag.add_task(Add).depends_on((v1, &v2));
+    let mul23 = dag.add_task(Multiply).depends_on((&v2, v3));
 
     // Layer 2
     let final_sum = dag.add_task(Add).depends_on((&sum12, &mul23));

--- a/tests/tracing/without_tracing.rs
+++ b/tests/tracing/without_tracing.rs
@@ -27,7 +27,7 @@ async fn test_basic_dag_without_tracing() {
 
     let a = dag.add_task(Value(2));
     let b = dag.add_task(Value(3));
-    let sum = dag.add_task(Add).depends_on((&a, &b));
+    let sum = dag.add_task(Add).depends_on((a, b));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -46,8 +46,8 @@ async fn test_complex_dag_without_tracing() {
     let v3 = dag.add_task(Value(3));
     let v4 = dag.add_task(Value(4));
 
-    let sum12 = dag.add_task(Add).depends_on((&v1, &v2));
-    let sum34 = dag.add_task(Add).depends_on((&v3, &v4));
+    let sum12 = dag.add_task(Add).depends_on((v1, v2));
+    let sum34 = dag.add_task(Add).depends_on((v3, v4));
     let final_sum = dag.add_task(Add).depends_on((&sum12, &sum34));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))

--- a/tests/type_safety/complex.rs
+++ b/tests/type_safety/complex.rs
@@ -27,7 +27,7 @@ async fn test_complex_type_safety() {
         .unwrap();
 
     // Correct type works
-    let custom = dag.get(&custom_task).unwrap();
+    let custom = dag.get(custom_task).unwrap();
     assert_eq!(custom.value, 42);
 
     // Type safety is enforced at compile time - we cannot get with wrong types
@@ -51,8 +51,8 @@ async fn test_generic_type_safety() {
         .unwrap();
 
     // Correct types work
-    assert_eq!(dag.get(&vec_i32).unwrap(), vec![1, 2, 3]);
-    assert!(dag.get(&vec_string).is_ok());
+    assert_eq!(dag.get(vec_i32).unwrap(), vec![1, 2, 3]);
+    assert!(dag.get(vec_string).is_ok());
 }
 
 #[tokio::test]
@@ -71,8 +71,8 @@ async fn test_option_result_type_safety() {
         .unwrap();
 
     // Correct wrapped types work
-    assert_eq!(dag.get(&opt_task).unwrap(), Some(42));
-    assert!(dag.get(&result_task).is_ok());
+    assert_eq!(dag.get(opt_task).unwrap(), Some(42));
+    assert!(dag.get(result_task).is_ok());
 }
 
 #[tokio::test]
@@ -94,7 +94,7 @@ async fn test_zero_sized_type_safety() {
         .unwrap();
 
     // Correct ZSTs work
-    assert!(dag.get(&zst1_task).is_ok());
+    assert!(dag.get(zst1_task).is_ok());
 }
 
 #[tokio::test]
@@ -115,13 +115,13 @@ async fn test_type_safety_with_many_types() {
         .unwrap();
 
     // Each type works correctly
-    assert_eq!(dag.get(&i32_task).unwrap(), 42i32);
-    assert_eq!(dag.get(&i64_task).unwrap(), 42i64);
-    assert_eq!(dag.get(&u32_task).unwrap(), 42u32);
-    assert_eq!(dag.get(&f32_task).unwrap(), 42.0f32);
-    assert_eq!(dag.get(&f64_task).unwrap(), 42.0f64);
-    assert_eq!(dag.get(&string_task).unwrap(), "42".to_string());
-    assert!(dag.get(&bool_task).unwrap());
+    assert_eq!(dag.get(i32_task).unwrap(), 42i32);
+    assert_eq!(dag.get(i64_task).unwrap(), 42i64);
+    assert_eq!(dag.get(u32_task).unwrap(), 42u32);
+    assert_eq!(dag.get(f32_task).unwrap(), 42.0f32);
+    assert_eq!(dag.get(f64_task).unwrap(), 42.0f64);
+    assert_eq!(dag.get(string_task).unwrap(), "42".to_string());
+    assert!(dag.get(bool_task).unwrap());
 }
 
 #[tokio::test]
@@ -134,7 +134,7 @@ async fn test_type_safety_single_dependency() {
     // This compiles because types match (i32 -> i32)
     let transform = dag
         .add_task(task_fn(|x: i32| async move { x * 2 }))
-        .depends_on(&source);
+        .depends_on(source);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -156,7 +156,7 @@ async fn test_type_safety_tuple_dependencies() {
         .add_task(task_fn(|(x, s, b): (i32, String, bool)| async move {
             format!("{}: {} ({})", s, x, b)
         }))
-        .depends_on((&a, &b, &c));
+        .depends_on((a, b, c));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -177,9 +177,9 @@ async fn test_type_safety_different_output_types() {
         .await
         .unwrap();
 
-    assert_eq!(dag.get(&int_source).unwrap(), 42);
-    assert_eq!(dag.get(&str_source).unwrap(), "test");
-    assert_eq!(dag.get(&vec_source).unwrap(), vec![1, 2, 3]);
+    assert_eq!(dag.get(int_source).unwrap(), 42);
+    assert_eq!(dag.get(str_source).unwrap(), "test");
+    assert_eq!(dag.get(vec_source).unwrap(), vec![1, 2, 3]);
 }
 
 #[tokio::test]
@@ -226,7 +226,7 @@ async fn test_type_safety_with_generics() {
         .add_task(task_fn(
             |opt: Option<i32>| async move { opt.map(|x| x * 2) },
         ))
-        .depends_on(&source);
+        .depends_on(source);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -240,7 +240,7 @@ async fn test_type_safety_with_generics() {
         .add_task(task_fn(
             |opt: Option<i32>| async move { opt.map(|x| x * 2) },
         ))
-        .depends_on(&source2);
+        .depends_on(source2);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await
@@ -262,7 +262,7 @@ async fn test_large_tuple_input() {
         .add_task(task_fn(
             |(a, b, c, d, e): (i32, i32, i32, i32, i32)| async move { a + b + c + d + e },
         ))
-        .depends_on((&a, &b, &c, &d, &e));
+        .depends_on((a, b, c, d, e));
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await

--- a/tests/type_safety/handles.rs
+++ b/tests/type_safety/handles.rs
@@ -21,7 +21,7 @@ async fn test_get_with_wrong_type_returns_none() {
         .unwrap();
 
     // Verify correct type works
-    assert_eq!(dag.get(&int_task), Ok(42i32));
+    assert_eq!(dag.get(int_task), Ok(42i32));
 
     // The type safety is enforced at compile time
     // We cannot create fake handles with wrong types without accessing private fields
@@ -42,8 +42,8 @@ async fn test_handle_preserves_type() {
         .unwrap();
 
     // Get with correct types
-    assert_eq!(dag.get(&string_task).unwrap(), "hello".to_string());
-    assert_eq!(dag.get(&int_task).unwrap(), 42);
+    assert_eq!(dag.get(string_task).unwrap(), "hello".to_string());
+    assert_eq!(dag.get(int_task).unwrap(), 42);
 
     // Type safety is enforced at compile time - we cannot create wrong-typed handles
 }
@@ -53,15 +53,15 @@ async fn test_type_safety_handle_reuse() {
     // Verify that handles maintain type safety across reuse
     let dag = DagRunner::new();
 
-    let source = dag.add_task(task_fn(|_: ()| async { 100i32 }));
+    let source: TaskHandle<_> = dag.add_task(task_fn(|_: ()| async { 100i32 })).into();
 
     // Use the same source handle multiple times
     let double = dag
         .add_task(task_fn(|x: i32| async move { x * 2 }))
-        .depends_on(&source);
+        .depends_on(source);
     let triple = dag
         .add_task(task_fn(|x: i32| async move { x * 3 }))
-        .depends_on(&source);
+        .depends_on(source);
 
     dag.run(|fut| tokio::spawn(fut).map(Result::unwrap))
         .await


### PR DESCRIPTION
Previously, the fact that TaskBuilder could be borrowed and used as input to `depends_on` meant that the compile-time cycle prevention guarantees could be trivially bypassed:

```rust
use dagx::{DagRunner, Task, task};

struct CircularTask;

#[task]
impl CircularTask {
    fn run() -> () {}
}

// This compiles and passes, even though it shouldn't do either
#[tokio::test]
async fn circular_dep() {
    let dag = DagRunner::new();

    let circular_task_1 = dag.add_task(CircularTask);
    let circular_task_2 = dag.add_task(CircularTask);
    let circular_task_1 = circular_task_1.depends_on(&circular_task_2);
    circular_task_2.depends_on(&circular_task_1);

    dag.run(|_fut| panic!()).await.unwrap();
}
```

This PR adjusts the semantics of TaskBuilder so that it can't be borrowed as a dependency by another crate, but needs to be consumed or explicitly converted to a TaskHandle first.

It also makes it possible to specify dependencies as mixed tuples of TaskBuilder, &TaskHandle, and TaskHandle, which was previously not possible.

This is a breaking change.